### PR TITLE
Update Stripe API version

### DIFF
--- a/dist/src/app/api/create-checkout-session/route.ts
+++ b/dist/src/app/api/create-checkout-session/route.ts
@@ -6,7 +6,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 export async function POST(request: Request) {

--- a/dist/src/app/api/create-payment-link/route.ts
+++ b/dist/src/app/api/create-payment-link/route.ts
@@ -6,7 +6,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 export async function POST(request: Request) {

--- a/dist/src/app/api/verify-session/route.ts
+++ b/dist/src/app/api/verify-session/route.ts
@@ -6,7 +6,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 export async function GET(request: Request) {

--- a/dist/src/app/api/webhooks/stripe/route.ts
+++ b/dist/src/app/api/webhooks/stripe/route.ts
@@ -8,7 +8,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;

--- a/src/app/api/capture-payment/route.ts
+++ b/src/app/api/capture-payment/route.ts
@@ -6,7 +6,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 export async function POST(request: Request) {

--- a/src/app/api/create-checkout-session/route.ts
+++ b/src/app/api/create-checkout-session/route.ts
@@ -6,7 +6,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 export async function POST(request: Request) {

--- a/src/app/api/create-payment-intent/route.ts
+++ b/src/app/api/create-payment-intent/route.ts
@@ -8,7 +8,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 export async function POST(request: Request) {

--- a/src/app/api/create-payment-link/route.ts
+++ b/src/app/api/create-payment-link/route.ts
@@ -6,7 +6,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 export async function POST(request: Request) {

--- a/src/app/api/handle-no-show/route.ts
+++ b/src/app/api/handle-no-show/route.ts
@@ -8,7 +8,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 export async function POST(request: Request) {

--- a/src/app/api/verify-session/route.ts
+++ b/src/app/api/verify-session/route.ts
@@ -6,7 +6,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 export async function GET(request: Request) {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -8,7 +8,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-05-28.basil',
+  apiVersion: '2024-03-14',
 });
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;


### PR DESCRIPTION
## Summary
- use Stripe API version `2024-03-14` instead of the placeholder `2025-05-28.basil`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683faef11cac83229d61b8cfa581f8ad