### PR TITLE
Fix payment status for manual capture flow

### DIFF
--- a/dist/src/app/api/webhooks/stripe/route.ts
+++ b/dist/src/app/api/webhooks/stripe/route.ts
@@ -65,7 +65,7 @@ export async function POST(request: Request) {
         const bookingId = session.metadata?.bookingId;
 
         if (bookingId) {
-          await updateBookingStatus(bookingId, 'Confirmed', 'Paid', session.id);
+          await updateBookingStatus(bookingId, 'Confirmed', 'Authorized', session.id);
         }
         break;
       }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: Request) {
       await updateBookingStatus(
         bookingId,
         'Scheduled',
-        'Paid',
+        'Authorized',
         session.id,
         session.payment_intent as string
       );


### PR DESCRIPTION
## Summary
- mark checkout session completion as `Authorized`
- keep `Paid` status only after `payment_intent.succeeded`

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683faed69688832285caba4d56c9986e